### PR TITLE
Update extensions.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
     "astro-build.astro-vscode",
-    "stylelint.vscode-stylelint"
+    "stylelint.vscode-stylelint",
+    "redhat.vscode-yaml"
   ]
 }


### PR DESCRIPTION
Add redhat extension for yaml. 
This enables users schema validation on the CloudCannon config.  