### PR TITLE
Change blog image type

### DIFF
--- a/.cloudcannon/schemas/blog-post.md
+++ b/.cloudcannon/schemas/blog-post.md
@@ -3,6 +3,6 @@ title:
 description:
 pubDate:
 author: Anonymous
-image:
+image: ""
 tags: []
 ---

--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -58,11 +58,10 @@ collections_config:
         comment: The author of the blog post.
       image:
         type: image
-        comment: Required image path for the blog post.
+        comment: Optional image path for the blog post.
         options:
           paths:
             uploads: src/assets/images
-          required: true
       tags:
         type: text
         comment: Comma-separated list of tags.


### PR DESCRIPTION
# Motivation

1. Text for an image is difficult for an editor creating a blog post.
<img width="1721" height="1157" alt="Screenshot 2026-01-15 at 4 36 37 PM" src="https://github.com/user-attachments/assets/5cd5fe73-95aa-4cd0-91ef-e3e35282e114" />

# Solve

Change from text to image type.
<img width="1716" height="1362" alt="Screenshot 2026-01-15 at 4 51 57 PM" src="https://github.com/user-attachments/assets/8a095c73-9848-41b6-85d5-58594bc332f0" />
