### PR TITLE
Fix: make embed a paired template

### DIFF
--- a/src/components/building-blocks/core-elements/embed/embed.cloudcannon.snippets.yml
+++ b/src/components/building-blocks/core-elements/embed/embed.cloudcannon.snippets.yml
@@ -1,15 +1,20 @@
 embed:
-  template: mdx_component
+  template: mdx_paired_component
   inline: false
   preview:
     text:
       - Embed
+    subtext:
+      - key: html
     icon: data_object
   definitions:
-    component_name: Embed
+    component_name: embed
+    content_key: html
     named_args:
-      - editor_key: html
+      - editor_key: id
         type: string
+        optional: true
+        remove_empty: true
       - editor_key: aspectRatio
         type: string
         optional: true


### PR DESCRIPTION
Previously the embed would break the build if you had quotes, newlines etc. Converting it to a paired snippet template doesn't require any changes to the component itself.